### PR TITLE
The current image on dockerhub is for x86 architectures, and will not…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.8.8-alpine
+FROM python:3.9-alpine3.12
+
+RUN python3 -m pip install --upgrade pip
 
 ARG unprivileged_user=app
 ARG sources_root=/usr/src/${unprivileged_user}


### PR DESCRIPTION
… work on arm based architectures. Previously using the dockerfile to build a new image did not work due to a bug with the alpine3.13 base image. This fix utilizes a different alpine linux image, and adds a command to upgrade pip in the Dockerfile. This allows a new image to be built on arm based architectures. In reference to #3 .

# What has changed

-
-
-

_Keep the only the checklist based on what you about to do - finish a Feature or do a Release?_

# Feature checklist

- [ ] [`[Unreleased]`](../blob/develop/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/develop/CHANGELOG.md) is updated.
- [ ] [README.md](../blob/develop/README.md) file is updated.
- [ ] Feature branch is deleted.

# Release checklist

- [ ] [`[<VERSION>]`](../blob/develop/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/develop/CHANGELOG.md) is created.
- [ ] Links in the bottom of [CHANGELOG.md](../blob/develop/CHANGELOG.md) are updated.
- [ ] Version number is updated in [src/__init__.py](../blob/develop/src/__init__.py).

**GitHub release**

- [ ] A [new release](../releases/new) is created on GitHub.
- [ ] `<VERSION>` is used as title.
- [ ] The following is used as description: `[Change log](../../blob/develop/CHANGELOG.md#<ANCHOR>)`
- [ ] `<ANCHOR>` matches one in live [CHANGELOG.md](../blob/develop/CHANGELOG.md).
 
