### PR TITLE
Add support for using @ Todoist labels for difficulty

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,4 +21,7 @@ HABITICA_API_KEY=
 # Defines how Todoist priorities map to Habitica difficulties. Keys/values are case-insensitive and can be both names or numerical values defines by the APIs. See https://habitica.com/apidoc/#api-Task-CreateUserTasks and https://developer.todoist.com/sync/v9/#items for numerical values definitions.
 # PRIORITY_TO_DIFFICULTY={'P1': 'HARD', 'P2': 'MEDIUM', 'P3': 'EASY', 'P4': 'TRIVIAL'}
 
+# Defines how Todoist labels map to Habitica difficulties. Keys are case-insensitive. See https://habitica.com/apidoc/#api-Task-CreateUserTasks for difficulty values. If a task has no matching label, the `priority_to_difficulty` mapping is used. If a task has multiple labels, the highest difficulty is used.
+# LABEL_TO_DIFFICULTY=
+
 # Auto-generated content end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Types of changes are:
 
 ## [Unreleased]
 
+## [3.4.1] - 2024-12-26
+
+### Fixes
+
+- Make the configuration options [`LABEL_TO_DIFFICULTY`](README.md#environment-variables) and [`PRIORITY_TO_DIFFICULTY`](README.md#environment-variables) more tolerant to different value types.
+
+## [3.4.0] - 2024-12-21
+
+### Features
+
+- Added configuration option [`LABEL_TO_DIFFICULTY`](README.md#environment-variables) to define how Todoist labels map to Habitica difficulties. If a task has no matching label, the `PRIORITY_TO_DIFFICULTY` mapping is used. If a task has multiple labels, the highest difficulty is used.
+
 ## [3.3.0] - 2024-12-15
 
 ### Features
@@ -199,7 +211,9 @@ Types of changes are:
 
 - Initial release
 
-[Unreleased]: https://github.com/radeklat/todoist-habitica-sync/compare/3.3.0...HEAD
+[Unreleased]: https://github.com/radeklat/todoist-habitica-sync/compare/3.4.1...HEAD
+[3.4.1]: https://github.com/radeklat/todoist-habitica-sync/compare/3.4.0...3.4.1
+[3.4.0]: https://github.com/radeklat/todoist-habitica-sync/compare/3.3.0...3.4.0
 [3.3.0]: https://github.com/radeklat/todoist-habitica-sync/compare/3.2.1...3.3.0
 [3.2.1]: https://github.com/radeklat/todoist-habitica-sync/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/radeklat/todoist-habitica-sync/compare/3.1.0...3.2.0

--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ Where to store synchronisation details. No need to change.
 *Optional*, default value: `{'P1': 'HARD', 'P2': 'MEDIUM', 'P3': 'EASY', 'P4': 'TRIVIAL'}`
 
 Defines how Todoist priorities map to Habitica difficulties. Keys/values are case-insensitive and can be both names or numerical values defines by the APIs. See https://habitica.com/apidoc/#api-Task-CreateUserTasks and https://developer.todoist.com/sync/v9/#items for numerical values definitions.
+
+## `LABEL_TO_DIFFICULTY`
+
+*Optional*, default value: `{}`
+
+Defines how Todoist labels map to Habitica difficulties. Keys are case-insensitive. See https://habitica.com/apidoc/#api-Task-CreateUserTasks for difficulty values.
 <!-- settings-doc end -->
 
 # Resetting sync cache
@@ -238,4 +244,3 @@ To reset the cache:
 
 * Synchronise overdue task to cause damage in habitica
 * Parse difficulty from string (similar to p0-p4 in Todoist)
-* Use @ Todoist labels for difficulty

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ Defines how Todoist priorities map to Habitica difficulties. Keys/values are cas
 
 ## `LABEL_TO_DIFFICULTY`
 
-*Optional*, default value: `{}`
+*Optional*
 
-Defines how Todoist labels map to Habitica difficulties. Keys are case-insensitive. See https://habitica.com/apidoc/#api-Task-CreateUserTasks for difficulty values.
+Defines how Todoist labels map to Habitica difficulties. Keys are case-insensitive. See https://habitica.com/apidoc/#api-Task-CreateUserTasks for difficulty values. If a task has no matching label, the `priority_to_difficulty` mapping is used. If a task has multiple labels, the highest difficulty is used.
 <!-- settings-doc end -->
 
 # Resetting sync cache
@@ -243,4 +243,3 @@ To reset the cache:
 # Planned work
 
 * Synchronise overdue task to cause damage in habitica
-* Parse difficulty from string (similar to p0-p4 in Todoist)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "todoist-habitica-sync"
-version = "3.3.0"
+version = "3.4.1"
 description = "One way synchronisation from Todoist to Habitica."
 authors = ["Radek Lát <radek.lat@gmail.com>"]
 homepage = "https://github.com/radeklat/todoist-habitica-sync"

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -16,7 +17,7 @@ _DEFAULT_PRIORITY_TO_DIFFICULTY = {
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file_encoding="utf-8")
 
     todoist_user_id: int | None = Field(
         None,
@@ -56,7 +57,9 @@ class Settings(BaseSettings):
         default_factory=dict,
         description=(
             "Defines how Todoist labels map to Habitica difficulties. Keys are case-insensitive. "
-            "See https://habitica.com/apidoc/#api-Task-CreateUserTasks for difficulty values."
+            "See https://habitica.com/apidoc/#api-Task-CreateUserTasks for difficulty values. If a task "
+            "has no matching label, the `priority_to_difficulty` mapping is used. If a task has multiple "
+            "labels, the highest difficulty is used."
         ),
     )
 
@@ -67,16 +70,32 @@ class Settings(BaseSettings):
 
     @field_validator("priority_to_difficulty", mode="before")
     @classmethod
-    def tranforms_enum_names_to_values(
+    def transform_enum_names_to_values(
         cls,
-        priority_to_difficulty: dict[str | TodoistPriority, str | HabiticaDifficulty],
-    ) -> dict[TodoistPriority, HabiticaDifficulty]:
-        return {
-            TodoistPriority[priority.upper()] if isinstance(priority, str) else priority: (
-                HabiticaDifficulty[difficulty.upper()] if isinstance(difficulty, str) else difficulty
-            )
-            for priority, difficulty in priority_to_difficulty.items()
-        }
+        priority_to_difficulty: dict[str | int | float | TodoistPriority, str | HabiticaDifficulty],
+    ) -> dict[TodoistPriority | str, HabiticaDifficulty | float | int]:
+        output: dict[Any, Any] = {}  # disable type checking for the dict values as it gets it wrong and tests cover it
+
+        for priority, difficulty in priority_to_difficulty.items():
+            if isinstance(priority, str):
+                try:
+                    priority = int(priority)
+                except ValueError:
+                    # If it's not a number, it could be an enum name
+                    priority = TodoistPriority[priority.upper()]  # type: ignore[union-attr]
+
+            if isinstance(difficulty, str):
+                try:
+                    float(difficulty)  # If it's a number, it's an enum value
+                except ValueError:  # If it's not a number, it's an enum name
+                    difficulty = HabiticaDifficulty[difficulty.upper()]
+
+            if isinstance(difficulty, (float, int)):  # If it's a number, it's an enum value
+                difficulty = str(difficulty)
+
+            output[priority] = difficulty
+
+        return output
 
     @field_validator("priority_to_difficulty")
     @classmethod
@@ -91,26 +110,17 @@ class Settings(BaseSettings):
     @field_validator("label_to_difficulty", mode="before")
     @classmethod
     def transform_label_to_difficulty(
-        cls,
-        label_to_difficulty: dict[str, str | HabiticaDifficulty],
+        cls, label_to_difficulty: dict[str, str | HabiticaDifficulty]
     ) -> dict[str, HabiticaDifficulty]:
         return {
-            label.lower(): (
-                HabiticaDifficulty[difficulty.upper()] if isinstance(difficulty, str) else difficulty
-            )
+            label.lower(): (HabiticaDifficulty[difficulty.upper()] if isinstance(difficulty, str) else difficulty)
             for label, difficulty in label_to_difficulty.items()
         }
-
-    @field_validator("label_to_difficulty")
-    @classmethod
-    def validate_label_to_difficulty(cls, value: dict[str, HabiticaDifficulty]):
-        # Ensure all values are valid HabiticaDifficulty
-        for difficulty in value.values():
-            if not isinstance(difficulty, HabiticaDifficulty):
-                raise ValueError(f"Invalid difficulty value: {difficulty}")
-        return value
 
 
 @lru_cache(maxsize=1)
 def get_settings():
+    # We don't want to read the environment variables in the tests
+    Settings.model_config["env_file"] = ".env"
+
     return Settings()

--- a/src/habitica_api.py
+++ b/src/habitica_api.py
@@ -5,6 +5,7 @@ import requests
 from pydantic import BaseModel, ConfigDict, Field
 
 from delay import DelayTimer
+from models.habitica import HabiticaDifficulty
 
 _API_URI_BASE: Final[str] = "https://habitica.com/api/v3"
 _SUCCESS_CODES = frozenset([requests.codes.ok, requests.codes.created])  # pylint: disable=no-member
@@ -83,9 +84,9 @@ class HabiticaAPI:
 
         return res.json()["data"]
 
-    def create_task(self, text: str, priority: float) -> dict[str, Any]:
+    def create_task(self, text: str, priority: HabiticaDifficulty) -> dict[str, Any]:
         """See https://habitica.com/apidoc/#api-Task-CreateUserTasks."""
-        return self.user.tasks(type="todo", text=text, priority=priority, _method="post")
+        return self.user.tasks(type="todo", text=text, priority=priority.value, _method="post")
 
     def score_task(self, task_id: str, direction: str = "up") -> None:
         """See https://habitica.com/apidoc/#api-Task-ScoreTask."""

--- a/src/main.py
+++ b/src/main.py
@@ -7,11 +7,12 @@ from typing import Final
 from pydantic import BaseModel, ConfigDict
 from requests import HTTPError
 
-from config import get_settings
+from config import Settings, get_settings
 from delay import DelayTimer
 from habitica_api import HabiticaAPI, HabiticaAPIHeaders
 from models.generic_task import GenericTask
-from models.todoist import TodoistTask
+from models.habitica import HabiticaDifficulty
+from models.todoist import TodoistPriority, TodoistTask
 from tasks_cache import TasksCache
 from todoist_api import TodoistAPI
 
@@ -224,18 +225,24 @@ class TasksSync:  # pylint: disable=too-few-public-methods
 
     def create_habitica_task(self, generic_task: GenericTask) -> None:
         previous_habitica_id = generic_task.habitica_task_id
-        generic_task.habitica_task_id = self.habitica.create_task(
-            generic_task.content,
-            self._get_task_difficulty(generic_task),
-        )["id"]
+        difficulty = self._get_task_difficulty(
+            get_settings(),
+            self._todoist.state.items[generic_task.todoist_task_id].labels,
+            generic_task.priority_enum,
+        )
+        generic_task.habitica_task_id = self.habitica.create_task(generic_task.content, difficulty)["id"]
         self._task_cache.save_task(generic_task, previous_habitica_id)
 
-    def _get_task_difficulty(self, generic_task: GenericTask) -> float:
-        settings = get_settings()
-        for label in self._todoist.state.items[generic_task.todoist_task_id].labels:
-            if label in settings.label_to_difficulty:
-                return settings.label_to_difficulty[label].value
-        return settings.priority_to_difficulty[generic_task.priority_enum].value
+    @staticmethod
+    def _get_task_difficulty(settings: Settings, labels: list[str], priority: TodoistPriority) -> HabiticaDifficulty:
+        label_difficulties = [
+            settings.label_to_difficulty[label_lower]
+            for label in labels
+            if (label_lower := label.lower()) in settings.label_to_difficulty
+        ]
+        if label_difficulties:
+            return max(label_difficulties)
+        return settings.priority_to_difficulty[priority]
 
     @property
     def initial_sync(self) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -226,9 +226,16 @@ class TasksSync:  # pylint: disable=too-few-public-methods
         previous_habitica_id = generic_task.habitica_task_id
         generic_task.habitica_task_id = self.habitica.create_task(
             generic_task.content,
-            get_settings().priority_to_difficulty[generic_task.priority_enum].value,
+            self._get_task_difficulty(generic_task),
         )["id"]
         self._task_cache.save_task(generic_task, previous_habitica_id)
+
+    def _get_task_difficulty(self, generic_task: GenericTask) -> float:
+        settings = get_settings()
+        for label in self._todoist.state.items[generic_task.todoist_task_id].labels:
+            if label in settings.label_to_difficulty:
+                return settings.label_to_difficulty[label].value
+        return settings.priority_to_difficulty[generic_task.priority_enum].value
 
     @property
     def initial_sync(self) -> bool:

--- a/src/models/habitica.py
+++ b/src/models/habitica.py
@@ -4,7 +4,13 @@ from enum import Enum
 class HabiticaDifficulty(Enum):
     """See https://habitica.com/apidoc/#api-Task-CreateUserTasks."""
 
-    TRIVIAL = 0.1
-    EASY = 1
-    MEDIUM = 1.5
-    HARD = 2
+    TRIVIAL = "0.1"
+    EASY = "1"
+    MEDIUM = "1.5"
+    HARD = "2"
+
+    def __lt__(self, other):
+        """To be able to use `min` and `max` on this enum."""
+        if isinstance(other, HabiticaDifficulty):
+            return float(self.value) < float(other.value)
+        return NotImplemented

--- a/src/models/todoist.py
+++ b/src/models/todoist.py
@@ -33,6 +33,7 @@ class TodoistTask(BaseModel):
     priority: int
     responsible_uid: str | None = None
     completed_at: str | None = None
+    labels: list[str] = Field(default_factory=list)
 
     # custom fields with default value
     due_date_utc_timestamp: int | None = None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -50,6 +50,46 @@ class TestConfigPriorityToDifficulty:
         assert Settings().priority_to_difficulty == _DEFAULT_PRIORITY_TO_DIFFICULTY
 
 
+class TestConfigLabelToDifficulty:
+    @staticmethod
+    def should_accept_label_to_difficulty():
+        settings = Settings(
+            label_to_difficulty={
+                "urgent": "hard",
+                "important": "medium",
+                "normal": "easy",
+                "low": "trivial",
+            }
+        )
+        assert settings.label_to_difficulty == {
+            "urgent": HabiticaDifficulty.HARD,
+            "important": HabiticaDifficulty.MEDIUM,
+            "normal": HabiticaDifficulty.EASY,
+            "low": HabiticaDifficulty.TRIVIAL,
+        }
+
+    @staticmethod
+    def should_ignore_casing_in_label_to_difficulty():
+        settings = Settings(
+            label_to_difficulty={
+                "Urgent": "Hard",
+                "IMPORTANT": "Medium",
+                "Normal": "Easy",
+                "low": "Trivial",
+            }
+        )
+        assert settings.label_to_difficulty == {
+            "urgent": HabiticaDifficulty.HARD,
+            "important": HabiticaDifficulty.MEDIUM,
+            "normal": HabiticaDifficulty.EASY,
+            "low": HabiticaDifficulty.TRIVIAL,
+        }
+
+    @staticmethod
+    def should_have_default_empty_label_to_difficulty():
+        assert Settings().label_to_difficulty == {}
+
+
 class TestGetSettings:
     @staticmethod
     def should_cache_settings():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -41,8 +41,13 @@ class TestConfigPriorityToDifficulty:
         assert settings.priority_to_difficulty == _DEFAULT_PRIORITY_TO_DIFFICULTY
 
     @staticmethod
-    def should_accept_keys_as_enum_values():
-        settings = Settings(priority_to_difficulty={4: 2, 3: 1.5, 2: 1, 1: 0.1})
+    def should_accept_keys_as_direct_enum_values():
+        settings = Settings(priority_to_difficulty={4: "2", 3: "1.5", 2: "1", 1: "0.1"})
+        assert settings.priority_to_difficulty == _DEFAULT_PRIORITY_TO_DIFFICULTY
+
+    @staticmethod
+    def should_accept_keys_as_indirect_enum_values():
+        settings = Settings(priority_to_difficulty={"4": 2, "3": 1.5, "2": 1, "1": 0.1})
         assert settings.priority_to_difficulty == _DEFAULT_PRIORITY_TO_DIFFICULTY
 
     @staticmethod
@@ -52,13 +57,13 @@ class TestConfigPriorityToDifficulty:
 
 class TestConfigLabelToDifficulty:
     @staticmethod
-    def should_accept_label_to_difficulty():
+    def should_accept_case_insensitive_labels():
         settings = Settings(
             label_to_difficulty={
-                "urgent": "hard",
-                "important": "medium",
-                "normal": "easy",
-                "low": "trivial",
+                "Urgent": "hard",
+                "Important": "medium",
+                "Normal": "easy",
+                "Low": "trivial",
             }
         )
         assert settings.label_to_difficulty == {
@@ -69,20 +74,16 @@ class TestConfigLabelToDifficulty:
         }
 
     @staticmethod
-    def should_ignore_casing_in_label_to_difficulty():
-        settings = Settings(
-            label_to_difficulty={
-                "Urgent": "Hard",
-                "IMPORTANT": "Medium",
-                "Normal": "Easy",
-                "low": "Trivial",
-            }
-        )
+    def should_allow_missing_difficulty_values():
+        settings = Settings(label_to_difficulty={"Urgent": "Hard"})
+        assert settings.label_to_difficulty == {"urgent": HabiticaDifficulty.HARD}
+
+    @staticmethod
+    def should_allow_multiple_identical_difficulty_values():
+        settings = Settings(label_to_difficulty={"Urgent": "Hard", "Important": "Hard"})
         assert settings.label_to_difficulty == {
             "urgent": HabiticaDifficulty.HARD,
-            "important": HabiticaDifficulty.MEDIUM,
-            "normal": HabiticaDifficulty.EASY,
-            "low": HabiticaDifficulty.TRIVIAL,
+            "important": HabiticaDifficulty.HARD,
         }
 
     @staticmethod

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,43 @@
+import pytest
+
+from config import Settings
+from main import TasksSync
+from models.habitica import HabiticaDifficulty
+from models.todoist import TodoistPriority
+
+
+class TestGetTaskDifficulty:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "labels",
+        [
+            pytest.param([], id="labels are not defined"),
+            pytest.param(["Urgent"], id="there is no matching label"),
+        ],
+    )
+    def should_use_task_priority_if(labels: list[str]):
+        settings = Settings(label_to_difficulty={})
+        assert TasksSync._get_task_difficulty(settings, labels, TodoistPriority.P1) == HabiticaDifficulty.HARD
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "labels",
+        [
+            pytest.param(["Urgent"], id="there is a matching label"),
+            pytest.param(["Urgent", "Important"], id="there are multiple labels"),
+        ],
+    )
+    def should_use_label_priority_if(labels: list[str]):
+        settings = Settings(label_to_difficulty={"urgent": HabiticaDifficulty.HARD})
+        assert TasksSync._get_task_difficulty(settings, labels, TodoistPriority.P1) == HabiticaDifficulty.HARD
+
+    @staticmethod
+    def should_use_highest_label_priority():
+        settings = Settings(
+            label_to_difficulty={
+                "urgent": HabiticaDifficulty.HARD,
+                "important": HabiticaDifficulty.MEDIUM,
+            }
+        )
+        labels = ["Urgent", "Important"]
+        assert TasksSync._get_task_difficulty(settings, labels, TodoistPriority.P1) == HabiticaDifficulty.HARD


### PR DESCRIPTION
Related to #56

Add support for using @ Todoist labels for difficulty instead of p1 p2 p3 p4.

* **src/config.py**
  - Add `label_to_difficulty` field in `Settings` class to map Todoist labels to Habitica difficulties.
  - Add validation and transformation logic for `label_to_difficulty` field.
* **README.md**
  - Add instructions on how to use @ Todoist labels for difficulty.
  - Update the "Planned work" section to reflect the new feature.
* **src/main.py**
  - Modify `TasksSync` class to check for Todoist labels and map them to Habitica difficulties using the new `label_to_difficulty` field.
  - Add `_get_task_difficulty` method to prioritize `label_to_difficulty` over `priority_to_difficulty`.
* **tests/unit/test_config.py**
  - Add tests to verify the new functionality of using @ Todoist labels for difficulty.
  - Update existing tests to ensure compatibility with the new `label_to_difficulty` field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/radeklat/todoist-habitica-sync/pull/59?shareId=1cfa17d9-e69f-4d15-8742-76b21a34f9b0).