### PR TITLE
replaced single quotes with double quotes

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,7 +19,7 @@ HABITICA_API_KEY=
 # DATABASE_FILE=.sync_cache/sync_cache.json
 
 # Defines how Todoist priorities map to Habitica difficulties. Keys/values are case-insensitive and can be both names or numerical values defines by the APIs. See https://habitica.com/apidoc/#api-Task-CreateUserTasks and https://developer.todoist.com/sync/v9/#items for numerical values definitions.
-# PRIORITY_TO_DIFFICULTY={'P1': 'HARD', 'P2': 'MEDIUM', 'P3': 'EASY', 'P4': 'TRIVIAL'}
+# PRIORITY_TO_DIFFICULTY={"P1": "HARD", "P2": "MEDIUM", "P3": "EASY", "P4": "TRIVIAL"}
 
 # Defines how Todoist labels map to Habitica difficulties. Keys are case-insensitive. See https://habitica.com/apidoc/#api-Task-CreateUserTasks for difficulty values. If a task has no matching label, the `priority_to_difficulty` mapping is used. If a task has multiple labels, the highest difficulty is used.
 # LABEL_TO_DIFFICULTY=


### PR DESCRIPTION
fixed the quotes in the .env template, since using single quotes breaks it